### PR TITLE
Return values when sending data

### DIFF
--- a/flask_mail.py
+++ b/flask_mail.py
@@ -517,7 +517,7 @@ class Message(object):
         """
         Verifies and sends the message.
         """
-        connection.send(self)
+        return connection.send(self)
 
     def add_recipient(self, recipient):
         """

--- a/flask_mail.py
+++ b/flask_mail.py
@@ -214,8 +214,9 @@ class Connection(object):
         if message.date is None:
             message.date = time.time()
 
+        ret = None
         if self.host:
-            self.host.sendmail(
+            ret = self.host.sendmail(
                 sanitize_address(envelope_from or message.sender),
                 list(sanitize_addresses(message.send_to)),
                 message.as_bytes() if PY3 else message.as_string(),
@@ -232,6 +233,8 @@ class Connection(object):
             if self.host:
                 self.host.quit()
                 self.host = self.configure_host()
+                
+        return ret
 
     def send_message(self, *args, **kwargs):
         """Shortcut for send(msg).

--- a/flask_mail.py
+++ b/flask_mail.py
@@ -599,7 +599,7 @@ class _MailMixin(object):
         :versionadded: 0.3.5
         """
 
-        self.send(Message(*args, **kwargs))
+        return self.send(Message(*args, **kwargs))
 
     def connect(self):
         """

--- a/flask_mail.py
+++ b/flask_mail.py
@@ -244,7 +244,7 @@ class Connection(object):
         :versionadded: 0.3.5
         """
 
-        self.send(Message(*args, **kwargs))
+        return self.send(Message(*args, **kwargs))
 
 
 class BadHeaderError(Exception):

--- a/flask_mail.py
+++ b/flask_mail.py
@@ -588,7 +588,7 @@ class _MailMixin(object):
         """
 
         with self.connect() as connection:
-            message.send(connection)
+            return message.send(connection)
 
     def send_message(self, *args, **kwargs):
         """


### PR DESCRIPTION
Noticed some useful commits that made `send`/`send_message` return `smtplib.sendmail` results. This looks handy in detecting immediate rejections.

Pulling this into my fork.

Thanks!